### PR TITLE
Ignore watching all node_modules and elm-stuff folders

### DIFF
--- a/lib/elm-doc-server.js
+++ b/lib/elm-doc-server.js
@@ -249,7 +249,7 @@ class DocServer {
     }
     const watcher = sane(this.dir, {
       glob,
-      ignored: ["node_modules", "elm-stuff"]
+      ignored: ["**/node_modules", "**/elm-stuff"]
     });
 
     watcher.on("ready", () => {


### PR DESCRIPTION
I have a project where the `examples` folder has its own node_modules folder, which results in elm-doc-preview failing to start because there are thousands of README.md files in there:

```
Previewing avh4/elm-program-test 2.3.1 from /Users/avh4/workspace/elm-program-test
  |> building documentation in /var/folders/.../T/elm-docs-....json
  |> gathering dependencies from /Users/avh4/.elm/0.19.0/package
Browse <http://localhost:8001> to see your documentation
  |> watching elm.json, README.md and *.elm files
2019-06-08 08:30 node[69888] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
2019-06-08 08:30 node[69888] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
Error: EMFILE: too many open files, watch
```

I saw that the intent here is to ignore node_modules, so this change makes the ignore list be globs so that node_modules and elm-stuff folders that are inside of subfolders will also be ignored.  (Making this change locally fixed the problem mentioned above of elm-doc-preview not being able to start when a large `examples/node_modules` exists.)