### PR TITLE
Report elm compiler errors for doc generation

### DIFF
--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -80,9 +80,8 @@ function fatal(...args: any[]) {
 }
 
 
-function elmFatalErrors(error:any) {
+function elmErrors(error:any) {
   console.log(elmErrorWithColor(error.errors));
-  process.exit(1);
 }
 
 
@@ -326,7 +325,7 @@ function buildPackageDocs(dir: string, elm: Elm, clean: boolean): Output {
   if (build.error) {
     error(`cannot build documentation (${build.error})`);
   } else if (build.stderr.toString().length > 0) {
-    elmFatalErrors(JSON.parse(build.stderr.toString()))
+    elmErrors(JSON.parse(build.stderr.toString()))
   }
   let docs;
   try {


### PR DESCRIPTION
Hey Rémi!

Currently if `elm-doc-preview` is run on a project and the elm-compiler fails due to something like a missing doc comment, the error that is reported is just that something failed.

This PR captures the error from the elm-compiler, prints it out with nice coloring, and then exits.

<img width="651" alt="Screen Shot 2020-12-09 at 8 21 29 PM" src="https://user-images.githubusercontent.com/3045469/101708855-23629e80-3a5c-11eb-88c9-26b9a01a1881.png">

Thanks for this tool, it's wonderful.
