### PR TITLE
Verbose option and always log Elm errors to console

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -32,7 +32,7 @@ function init() {
     )
     .option("-p, --port <port>", "the server listen port", Math.floor, 8000)
     .option("-r, --no-reload", "disable hot reloading")
-    .option("-v, --verbose", "verbose output (including errors to console when in server mode)");
+    .option("-v, --verbose", "verbose console output (including documentation errors in server mode, output mode always shows errors)");
 
   program.on("--help", () => {
     console.log("");

--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,8 @@ function init() {
       "generate docs and exit with status code (/dev/null supported)"
     )
     .option("-p, --port <port>", "the server listen port", Math.floor, 8000)
-    .option("-r, --no-reload", "disable hot reloading");
+    .option("-r, --no-reload", "disable hot reloading")
+    .option("-v, --verbose", "verbose output (including errors to console when in server mode)");
 
   program.on("--help", () => {
     console.log("");

--- a/cli.js
+++ b/cli.js
@@ -32,7 +32,7 @@ function init() {
     )
     .option("-p, --port <port>", "the server listen port", Math.floor, 8000)
     .option("-r, --no-reload", "disable hot reloading")
-    .option("-v, --verbose", "verbose console output (including documentation errors in server mode, output mode always shows errors)");
+    .option("-v, --verbose", "verbose console output");
 
   program.on("--help", () => {
     console.log("");

--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -359,7 +359,14 @@ function buildPackageDocs(
     error(`cannot build documentation (${build.error})`);
   } else if (build.stderr.toString().length > 0) {
     console.error("Errors detected.");
-    elmErrors(JSON.parse(build.stderr.toString()));
+    const errorString = build.stderr.toString();
+    try {
+      const json = JSON.parse(errorString);
+      elmErrors(json);
+    }
+    catch (err) {
+      console.log(errorString)
+    }
   }
   else {
     info("✅ Documentation build succeeded!")

--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -922,7 +922,7 @@ class DocServer {
         this.options.dir,
         this.elm,
         !this.options.debug,
-        true
+        this.options.verbose
       );
       info(`  |> writing documentation into ${filename}`);
       if (Array.isArray(docs) && docs.length > 0) {

--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -368,6 +368,9 @@ function buildPackageDocs(
       elmErrors(JSON.parse(build.stderr.toString()));
     }
   }
+  else {
+    info("✅ Documentation build succeeded!")
+  }
   let docs;
   try {
     docs = JSON.parse(fs.readFileSync(tmpFile.name).toString());


### PR DESCRIPTION
Thanks for making elm-doc-preview! I love it and use it all the time at work for application documentation. 💌

I use it in server mode locally, and run `elm-doc-preview --output /dev/null` in CI. However, when running locally, if I don't open the docs, I don't know if there's an error. I use Simon Lydell's [run-pty](https://github.com/lydell/run-pty?tab=readme-ov-file#shell-scripting) to run all of our tools in parallel. With elm-doc-preview, sometimes I don't get the feedback until CI runs. I'd like to have the errors on the console, so I could set the status in run-pty according to the output.

Without logging that there's an error, it's always green:
<img width="405" height="228" alt="image" src="https://github.com/user-attachments/assets/b6573e65-48a3-420f-ab9f-25dd687ff705" />

I might be able to add a separate process that runs `elm-doc-preview --output /dev/null`, but that seems wasteful and redundant.

Instead, I added a `console.error` if there's an error, and a `--verbose` option that will display the error details to the console when in server mode.

**Without `--verbose`**
<img width="897" height="282" alt="image" src="https://github.com/user-attachments/assets/1f910833-976c-464f-a06a-5185d40b2076" />

**With `--verbose`**
<img width="893" height="417" alt="image" src="https://github.com/user-attachments/assets/9818f7e3-7cba-488e-91c3-991d1df09037" />

I also considered that some of the port stubbing details might make sense to put behind the `--verbose` flag, too. We have a lot of them at work, and it floods the output.

Please let me know what you think.