### PR TITLE
Add initial flag: build docs when server starts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,8 @@ function init() {
       "generate docs and exit with status code (/dev/null supported)"
     )
     .option("-p, --port <port>", "the server listen port", Math.floor, 8000)
-    .option("-r, --no-reload", "disable hot reloading");
+    .option("-r, --no-reload", "disable hot reloading")
+    .option("--initial", "build docs when server starts");
 
   program.on("--help", () => {
     console.log("");

--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -786,7 +786,6 @@ class DocServer {
             ".",
             this.elm,
             !this.options.debug,
-            this.options.verbose,
           )
         }
       });

--- a/lib/elm-doc-server.ts
+++ b/lib/elm-doc-server.ts
@@ -32,6 +32,7 @@ interface Options {
   port: number;
   browser: boolean;
   reload: boolean;
+  initial: boolean;
 }
 
 interface Manifest {
@@ -577,6 +578,7 @@ class DocServer {
       browser = true,
       reload = true,
       debug = false,
+      initial = false,
     } = options || {};
     this.options = {
       address,
@@ -585,6 +587,7 @@ class DocServer {
       dir: fs.lstatSync(dir).isFile() ? path.dirname(dir) : path.resolve(dir),
       port,
       reload,
+      initial,
     };
 
     try {
@@ -776,6 +779,15 @@ class DocServer {
         }
         if (this.options.debug) {
           info(watcher.getWatched());
+        }
+        if (this.manifest && this.options.initial) {
+          buildDocs(
+            this.manifest,
+            ".",
+            this.elm,
+            !this.options.debug,
+            this.options.verbose,
+          )
         }
       });
   }


### PR DESCRIPTION
Add an `--initial` flag that builds the docs when the server starts.

<img width="1001" height="344" alt="image" src="https://github.com/user-attachments/assets/9bc2e509-2bbf-4462-85c6-adcd17d7fe8f" />

Related to https://github.com/dmy/elm-doc-preview/pull/60. Only really useful once errors are output in server mode. 